### PR TITLE
Replaced block quotes with code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ Edit "settings" to suit..
 
 Install this PPA https://launchpad.net/~managedit/+archive/openstack
 
-> apt-get install -y python-software-properties  
-> apt-add-repository -y ppa:managedit/openstack  
-> apt-get update
-> apt-get install -y managedit-openstack-pin  
+    apt-get install -y python-software-properties
+    apt-add-repository -y ppa:managedit/openstack
+    apt-get update
+    apt-get install -y managedit-openstack-pin
 
 Install and configure NTP
 
-> apt-get install ntp  
+    apt-get install ntp
 
 (Todo: Configure nodes to use controller as NTP source)
 
@@ -23,31 +23,31 @@ Install and configure NTP
 
 Install MySQL, RabbitMQ and ntp
 
-> apt-get install -y python-mysqldb mysql-server rabbitmq-server  
-> sed -i 's/server ntp.ubuntu.com/server ntp.ubuntu.com n\server 127.127.1.0 n\fudge 127.127.1.0 stratum 10/g' /etc/ntp.conf  
-> service ntp restart  
-> sed -i 's/127.0.0.1/0.0.0.0/g' /etc/mysql/my.cnf  
-> service mysql restart
+    apt-get install -y python-mysqldb mysql-server rabbitmq-server
+    sed -i 's/server ntp.ubuntu.com/server ntp.ubuntu.com n\server 127.127.1.0 n\fudge 127.127.1.0 stratum 10/g' /etc/ntp.conf
+    service ntp restart
+    sed -i 's/127.0.0.1/0.0.0.0/g' /etc/mysql/my.cnf
+    service mysql restart
 
 ## Install Keystone
 
 Run this, and do what it says!
 
-> ./keystone.sh
+    ./keystone.sh
 
 then test with:
 
-> ./keystone-test.sh
+    ./keystone-test.sh
 
 ## Install Glance
 
 Run this, and do what it says!
 
-> ./glance.sh
+    ./glance.sh
 
 then test with:
 
-> ./glance-test.sh
+    ./glance-test.sh
 
 ## Install Nova
 
@@ -55,22 +55,22 @@ then test with:
 
 Run this, and do what it says!
 
-> ./nova-controller.sh
+    ./nova-controller.sh
 
 ### Compute Node(s)
 
 Run this, and do what it says!
 
-> ./nova-compute.sh
+    ./nova-compute.sh
 
 Then test with:
 
-> ./nova-test.sh
+    ./nova-test.sh
 
 ## Install Dashboard
 
 Run this, and do what it says!
 
-> ./dashboard.sh
+    ./dashboard.sh
 
 then test by visiting http://$HOST_IP/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Edit "settings" to suit..
 Install this PPA https://launchpad.net/~managedit/+archive/openstack
 
     apt-get install -y python-software-properties
-    apt-add-repository -y ppa:managedit/openstack
+    apt-add-repository ppa:managedit/openstack
     apt-get update
     apt-get install -y managedit-openstack-pin
 


### PR DESCRIPTION
A line break was missing in the "Install this PPA" instructions, which lead to two apt-get commands appearing as one.

Code blocks avoid such issues :)
